### PR TITLE
getMigratedFiles should return plain array of strings

### DIFF
--- a/src/Migrations/Mixins/Migrate.js
+++ b/src/Migrations/Mixins/Migrate.js
@@ -242,7 +242,8 @@ Migrate._mapMigrationsToActions = function (migrationsList, direction) {
  */
 Migrate._getMigratedFiles = function * () {
   const db = yield this.database.connection('default')
-  return mquery().collection(db.collection(this.migrationsCollection)).find().select('name').sort('name')
+  const migratedFiles = yield mquery().collection(db.collection(this.migrationsCollection)).find().select('name').sort('name')
+  return _.map(migratedFiles, 'name')
 }
 
 /**


### PR DESCRIPTION
`Migrate._getMigratedFiles` should return plain array of strings, while currently it returns array of objects:
````
[ { _id: 5976e8c552b01292ad91cbfe,
    name: ... },
  { _id: 5976e8da77950692d361bf77,
    name: ... },
  { _id: 5976e916097e3992fec4e636,
    name: ... } ]
````